### PR TITLE
Protect against invalid payloads

### DIFF
--- a/client/src/dialogs/contactsimportpage.cpp
+++ b/client/src/dialogs/contactsimportpage.cpp
@@ -517,6 +517,7 @@ void ContactsImportPage::setChosenContacts(const QVector<ContactsSet> &contacts)
             for (int row = 0; row < mContactsModel->rowCount(); ++row) {
                 const QModelIndex index = mContactsModel->index(row, 0);
                 const Akonadi::Item item = index.data(Akonadi::EntityTreeModel::ItemRole).value<Akonadi::Item>();
+                Q_ASSERT(item.hasPayload<KContacts::Addressee>());
                 const KContacts::Addressee possibleMatch = item.payload<KContacts::Addressee>();
                 if (possibleMatch.preferredEmail() == addressee.preferredEmail()) {
                     MatchPair pair;

--- a/client/src/dialogs/contactsimportwizard.cpp
+++ b/client/src/dialogs/contactsimportwizard.cpp
@@ -98,6 +98,7 @@ void ContactsImportWizard::importItems(const QVector<Akonadi::Item> &items)
     connect(tracker, SIGNAL(finished()), SLOT(deleteLater()));
 
     foreach (const Akonadi::Item &item, items) {
+        Q_ASSERT(item.hasPayload<KContacts::Addressee>());
         const KContacts::Addressee contact = item.payload<KContacts::Addressee>();
         if (item.isValid()) {
             Akonadi::ItemModifyJob *job = new Akonadi::ItemModifyJob(item, this);

--- a/client/src/pages/page.cpp
+++ b/client/src/pages/page.cpp
@@ -285,17 +285,20 @@ void Page::slotRemoveItem()
     QString deleStr = i18n("The selected item will be deleted permanently!");
     switch (mType) {
     case Account: {
+        Q_ASSERT(item.hasPayload<SugarAccount>());
         SugarAccount acct = item.payload<SugarAccount>();
         deleStr = i18n("The account \"%1\" will be deleted permanently!", acct.name());
         break;
     }
     case Opportunity: {
+        Q_ASSERT(item.hasPayload<SugarOpportunity>());
         SugarOpportunity opp = item.payload<SugarOpportunity>();
         deleStr = i18n("The %1 opportunity \"%2\" will be deleted permanently!",
                        opp.tempAccountName(), opp.name());
         break;
     }
     case Contact: {
+        Q_ASSERT(item.hasPayload<KContacts::Addressee>());
         const auto contact = item.payload<KContacts::Addressee>();
         deleStr = i18n("The contact \"%1\" will be deleted permanently!", contact.fullEmail());
         break;
@@ -733,6 +736,7 @@ void Page::slotChangeFields()
         Item item = index.data(EntityTreeModel::ItemRole).value<Item>();
 
         if (mType == Account) {
+            Q_ASSERT(item.hasPayload<SugarAccount>());
             SugarAccount account = item.payload<SugarAccount>();
 
             if (field == CityField) {
@@ -749,6 +753,7 @@ void Page::slotChangeFields()
 
             item.setPayload(account);
         } else if (mType == Opportunity) {
+            Q_ASSERT(item.hasPayload<SugarOpportunity>());
             SugarOpportunity opportunity = item.payload<SugarOpportunity>();
 
             if (field == NextStepDateField) {
@@ -760,6 +765,7 @@ void Page::slotChangeFields()
 
             item.setPayload(opportunity);
         } else if (mType == Contact) {
+            Q_ASSERT(item.hasPayload<KContacts::Addressee>());
             KContacts::Addressee addressee = item.payload<KContacts::Addressee>();
 
             if (field == CityField) {

--- a/resources/sugarcrm/emailshandler.cpp
+++ b/resources/sugarcrm/emailshandler.cpp
@@ -132,12 +132,14 @@ void EmailsHandler::getExtraInformation(Akonadi::Item::List &items)
             if (pos == -1) {
                 qCWarning(FATCRM_SUGARCRMRESOURCE_LOG) << "Email not found:" << email_id;
             } else {
-                SugarEmail email = items[pos].payload<SugarEmail>();
+                auto &item = items[pos];
+                Q_ASSERT(item.hasPayload<SugarEmail>());
+                SugarEmail email = item.payload<SugarEmail>();
                 email.setDescription(description);
                 if (description.isEmpty()) {
                     email.setDescriptionHtml(descriptionHtml);
                 }
-                items[pos].setPayload<SugarEmail>(email);
+                item.setPayload<SugarEmail>(email);
             }
         }
     }


### PR DESCRIPTION
Got some Akonadi::PayloadExceptions when trying the Sugar CRM resource,
so I tried debugging this issue. Turns out my issue was a bogus
QT_PLUGIN_PATH, though.

This patch still makes sense