### PR TITLE
RFC: Reuse pages in child widgets

### DIFF
--- a/client/src/app/mainwindow.cpp
+++ b/client/src/app/mainwindow.cpp
@@ -66,6 +66,8 @@ using namespace Akonadi;
 
 #include "fatcrm_client_debug.h"
 
+MainWindow* MainWindow::s_instance = nullptr;
+
 MainWindow::MainWindow(bool displayOverlay)
     : QMainWindow(),
       mProgressBar(0),
@@ -76,7 +78,11 @@ MainWindow::MainWindow(bool displayOverlay)
       mInitialLoadingDone(false),
       mDisplayOverlay(displayOverlay)
 {
+    Q_ASSERT(!s_instance);
+    s_instance = this;
+
     mUi.setupUi(this);
+
     initialize(displayOverlay);
 
     /*

--- a/client/src/app/mainwindow.h
+++ b/client/src/app/mainwindow.h
@@ -57,6 +57,11 @@ public:
 
     ~MainWindow() override;
 
+    // HACK to expose functionality
+    static MainWindow* self() { return s_instance; }
+    // HACK to expose functionality
+    void addPage(Page *page);
+
     bool eventFilter(QObject *object, QEvent *event) Q_DECL_OVERRIDE;
 
 Q_SIGNALS:
@@ -103,7 +108,6 @@ private:
     void createActions();
     void setupActions();
     void createTabs();
-    void addPage(Page *page);
     void updateWindowTitle(bool online);
 
     Page *currentPage() const;
@@ -143,7 +147,7 @@ private:
     QStringList mPendingImportPaths;
     LoadingOverlay *mLoadingOverlay;
 
-
+    static MainWindow* s_instance;
 };
 
 #endif

--- a/client/src/details/details.cpp
+++ b/client/src/details/details.cpp
@@ -193,6 +193,10 @@ void Details::setEnumDefinitions(const EnumDefinitions &enums)
 
 void Details::setCollectionManager(CollectionManager *collectionManager)
 {
+    if (!collectionManager) {
+        return;
+    }
+
     Akonadi::Collection::Id coll = collectionManager->collectionIdForType(mType);
     //qDebug() << typeToString(mType) << coll << collectionManager->supportedFields(coll);
     setSupportedFields(collectionManager->supportedFields(coll));

--- a/client/src/models/opportunityfilterproxymodel.cpp
+++ b/client/src/models/opportunityfilterproxymodel.cpp
@@ -110,6 +110,10 @@ bool OpportunityFilterProxyModel::filterAcceptsRow(int row, const QModelIndex &p
     Q_ASSERT(item.hasPayload<SugarOpportunity>());
     const SugarOpportunity opportunity = item.payload<SugarOpportunity>();
 
+    if (!d->settings.accountId().isEmpty() && d->settings.accountId() != opportunity.accountId()) {
+        return false;
+    }
+
     const QStringList assignees = d->settings.assignees();
     if (!assignees.isEmpty() && !assignees.contains(opportunity.assignedUserName()))
         return false;

--- a/client/src/pages/opportunitiespage.cpp
+++ b/client/src/pages/opportunitiespage.cpp
@@ -66,6 +66,11 @@ OpportunitiesPage::OpportunitiesPage(QWidget *parent)
     mFilterUiWidget = new OpportunityFilterWidget(mOppFilterProxyModel, this);
     insertFilterWidget(mFilterUiWidget);
 }
+void OpportunitiesPage::hideFilterWidget()
+{
+    delete mFilterUiWidget;
+    mFilterUiWidget = nullptr;
+}
 
 OpportunitiesPage::~OpportunitiesPage()
 {

--- a/client/src/pages/opportunitiespage.h
+++ b/client/src/pages/opportunitiespage.h
@@ -37,6 +37,10 @@ public:
 
     ~OpportunitiesPage() override;
 
+    OpportunityFilterProxyModel *filterModel() const { return mOppFilterProxyModel; }
+
+    void hideFilterWidget();
+
     void setupModel() Q_DECL_OVERRIDE;
 
 protected:

--- a/client/src/pages/page.h
+++ b/client/src/pages/page.h
@@ -68,6 +68,9 @@ public:
     void printReport();
     KJob *clearTimestamp();
 
+    virtual void setupModel();
+
+
 Q_SIGNALS:
     void modelCreated(ItemsTreeModel *model);
     void statusMessage(const QString &);
@@ -96,7 +99,6 @@ protected:
     }
     void setFilter(FilterProxyModel *filter);
 
-    virtual void setupModel();
 
     void insertFilterWidget(QWidget *widget);
 

--- a/client/src/utilities/opportunityfiltersettings.cpp
+++ b/client/src/utilities/opportunityfiltersettings.cpp
@@ -34,6 +34,11 @@ OpportunityFilterSettings::OpportunityFilterSettings()
 {
 }
 
+void OpportunityFilterSettings::setAccountId(const QString &accountId)
+{
+    mAccountId = accountId;
+}
+
 void OpportunityFilterSettings::setAssignees(const QStringList &assignees, const QString &assigneeGroup)
 {
     mAssignees = assignees;

--- a/client/src/utilities/opportunityfiltersettings.h
+++ b/client/src/utilities/opportunityfiltersettings.h
@@ -39,6 +39,8 @@ public:
     OpportunityFilterSettings();
     // default copy ctor and operator= are wanted.
 
+    void setAccountId(const QString &accountId);
+    QString accountId() const { return mAccountId; }
     void setAssignees(const QStringList &assignees, const QString &assigneeGroup);
     QStringList assignees() const { return mAssignees; }
     QString assigneeGroup() const { return mAssigneeGroup; }
@@ -66,6 +68,7 @@ public:
     void load(const QSettings &settings, const QString &prefix);
 
 private:
+    QString mAccountId;
     QStringList mAssignees; // no filtering if empty
     QStringList mCountries; // no filtering if empty
     QString mAssigneeGroup; // user-visible description for <assignee>

--- a/client/src/widgets/associateddatawidget.cpp
+++ b/client/src/widgets/associateddatawidget.cpp
@@ -21,6 +21,8 @@
 #include "associateddatawidget.h"
 #include "ui_associateddatawidget.h"
 
+#include "mainwindow.h"
+
 #include <QStringListModel>
 
 AssociatedDataWidget::AssociatedDataWidget(QWidget *parent) :
@@ -28,10 +30,17 @@ AssociatedDataWidget::AssociatedDataWidget(QWidget *parent) :
     mUi(new Ui::AssociatedDataWidget)
 {
     mUi->setupUi(this);
-    connect(mUi->opportunitiesListView, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(editItem(QModelIndex)));
-    connect(mUi->opportunitiesListView, SIGNAL(returnPressed(QModelIndex)), this, SLOT(editItem(QModelIndex)));
+
     connect(mUi->contactsListView, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(editItem(QModelIndex)));
     connect(mUi->contactsListView, SIGNAL(returnPressed(QModelIndex)), this, SLOT(editItem(QModelIndex)));
+
+    // HACK: The page needs
+    // - the collection manager + linked items repository
+    // - online status tracking, etc.
+    MainWindow::self()->addPage(mUi->opportunitiesPage);
+    mUi->opportunitiesPage->setupModel();
+
+    mUi->opportunitiesPage->hideFilterWidget();
 }
 
 AssociatedDataWidget::~AssociatedDataWidget()
@@ -42,22 +51,20 @@ AssociatedDataWidget::~AssociatedDataWidget()
 void AssociatedDataWidget::hideOpportunityGui()
 {
     mUi->opportunitiesLabel->hide();
-    mUi->opportunitiesListView->hide();
+    mUi->opportunitiesPage->hide();
 }
 
 void AssociatedDataWidget::setContactsModel(QStringListModel *model)
 {
     mUi->contactsListView->setModel(model);
-
 }
 
-void AssociatedDataWidget::setOpportunitiesModel(QStringListModel *model)
+OpportunitiesPage *AssociatedDataWidget::opportunitiesPage() const
 {
-    mUi->opportunitiesListView->setModel(model);
+    return mUi->opportunitiesPage;
 }
 
 void AssociatedDataWidget::editItem(const QModelIndex &index)
 {
     emit openItem(index.data(Qt::DisplayRole).toString());
-
 }

--- a/client/src/widgets/associateddatawidget.h
+++ b/client/src/widgets/associateddatawidget.h
@@ -27,6 +27,9 @@ namespace Ui {
 class AssociatedDataWidget;
 }
 
+class OpportunitiesPage;
+
+class QAbstractItemModel;
 class QModelIndex;
 class QStringListModel;
 
@@ -39,8 +42,9 @@ public:
     ~AssociatedDataWidget() override;
 
     void hideOpportunityGui();
+
     void setContactsModel(QStringListModel *model);
-    void setOpportunitiesModel(QStringListModel *model);
+    OpportunitiesPage *opportunitiesPage() const;
 
 Q_SIGNALS:
     void openItem(const QString &item);

--- a/client/src/widgets/associateddatawidget.ui
+++ b/client/src/widgets/associateddatawidget.ui
@@ -28,10 +28,7 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="KeyPressEventListView" name="opportunitiesListView">
-        <property name="editTriggers">
-         <set>QAbstractItemView::NoEditTriggers</set>
-        </property>
+       <widget class="OpportunitiesPage" name="opportunitiesPage">
        </widget>
       </item>
      </layout>
@@ -67,6 +64,11 @@
    <class>KeyPressEventListView</class>
    <extends>QListView</extends>
    <header>utilities/keypresseventlistview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>OpportunitiesPage</class>
+   <extends>QWidget</extends>
+   <header>opportunitiespage.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
Lot's of work in progress, just showing off the idea: Show the opportunities page in more places, e.g. inside the account details widget. Same could be done for the accountspage later on.

Idea: We get all the features of the opportunities page inside child
widget as well (detailed tool tips when hovering opps, context menus,
etc.)

Problem: Page is tightly coupled to MainWindow right now, we'd need to
get rid off this coupling and make Page more reusable.
