### PR TITLE
limitString func: Pack multi-line better

### DIFF
--- a/kdcrmdata/kdcrmutils.cpp
+++ b/kdcrmdata/kdcrmutils.cpp
@@ -135,7 +135,8 @@ QString KDCRMUtils::limitString(const QString &str, int wantedParagraphs)
 
             if (!row.isEmpty()) {
                 ++collectedParagraphs;
-                output.append(row);
+                output.append(QLatin1Char(' '));
+                output.append(row.trimmed());
             }
         }
         return output;


### PR DESCRIPTION
Add spaces where it makes sense

Sample string:
  04Jan17:
  Dear sir/madam,
  ...

Before limitString() returned:
  04Jan17:Dear sir/madam,

After:
  04Jan17: Dear sir/madam,