### PR TITLE
Port away from kdelibs4support as much as possible

### DIFF
--- a/client/src/CMakeLists.txt
+++ b/client/src/CMakeLists.txt
@@ -125,9 +125,10 @@ target_link_libraries(fatcrmprivate
   kdcrmdata
   KF5::AkonadiWidgets
   KF5::Contacts
-  KF5::KDELibs4Support
   KF5::DBusAddons
-  )
+  KF5::KIOWidgets
+  Qt5::PrintSupport
+)
 
 
 target_link_libraries(fatcrmprivate

--- a/client/src/dialogs/documentswindow.cpp
+++ b/client/src/dialogs/documentswindow.cpp
@@ -31,12 +31,12 @@
 #include <AkonadiCore/ItemModifyJob>
 
 #include <KLocalizedString>
-#include <KMimeType>
 #include <KRun>
 
 #include <QComboBox>
 #include <QFileDialog>
 #include <QLabel>
+#include <QMimeType>
 #include <QMessageBox>
 #include <QPlainTextEdit>
 #include <QScrollBar>
@@ -239,9 +239,11 @@ void DocumentsWindow::urlClicked(const QString &url)
         const QString filePath = reply.value();
         if (!filePath.isEmpty()) {
             const QUrl localFile = QUrl::fromLocalFile(filePath);
-            const KMimeType::Ptr mimeType = KMimeType::findByUrl(localFile);
 
-            KRun::runUrl(localFile, mimeType ? mimeType->name() : QString(), this, true, false);
+            QMimeDatabase db;
+            const auto mimeType = db.mimeTypeForUrl(localFile);
+
+            KRun::runUrl(localFile, mimeType.isValid() ? mimeType.name() : QString(), this, true, false);
 
             return;
         }

--- a/resources/salesforce/CMakeLists.txt
+++ b/resources/salesforce/CMakeLists.txt
@@ -34,11 +34,13 @@ add_executable(akonadi_salesforce_resource ${salesforceresource_SRCS})
 target_link_libraries(akonadi_salesforce_resource
   ${KDSoap_LIBRARIES}
   KF5::Contacts
-  KF5::KDELibs4Support
   Qt5::DBus
   Qt5::Core
   KF5::AkonadiCore
   KF5::AkonadiAgentBase
+  KF5::I18n
+  KF5::KIOWidgets
+  KF5::WindowSystem
 )
 
 install(TARGETS akonadi_salesforce_resource ${INSTALL_TARGETS_DEFAULT_ARGS})

--- a/resources/sugarcrm/CMakeLists.txt
+++ b/resources/sugarcrm/CMakeLists.txt
@@ -69,7 +69,7 @@ target_link_libraries(akonadi_sugarcrm_resource_private
   ${KDSoap_LIBRARIES}
   KF5::Contacts
   KF5::CalendarCore
-  KF5::KDELibs4Support
+  KF5::KDELibs4Support # b/c of KDateTime; KF5::CalendarCore uses it
   Qt5::DBus
   Qt5::Core
   KF5::CalendarCore

--- a/resources/sugarcrm/itemtransferinterface.cpp
+++ b/resources/sugarcrm/itemtransferinterface.cpp
@@ -26,7 +26,7 @@
 #include "sugarcrmresource.h"
 
 #include <KCodecs>
-#include <KTempDir>
+#include <QTemporaryDir>
 
 #include <QFile>
 
@@ -47,10 +47,10 @@ QString ItemTransferInterface::downloadDocumentRevision(const QString &documentR
     const KDSoapGenerated::TNS__Return_document_revision result = soap->get_document_revision(sessionId, documentRevisionId);
     const KDSoapGenerated::TNS__Document_revision revision = result.document_revision();
 
-    KTempDir tempDir;
+    QTemporaryDir tempDir;
     tempDir.setAutoRemove(false);
 
-    const QString fullPath(tempDir.name() + revision.filename());
+    const QString fullPath(tempDir.path() + QLatin1Char('/') + revision.filename());
     QFile file(fullPath);
     if (!file.open(QIODevice::WriteOnly)) {
         tempDir.setAutoRemove(true);

--- a/resources/sugarcrm/modulename.cpp
+++ b/resources/sugarcrm/modulename.cpp
@@ -1,7 +1,8 @@
+#include "modulename.h"
+
+#include <QDebug>
 #include <QString>
 #include <QMap>
-#include <KDebug>
-#include "modulename.h"
 
 struct ModuleEntry {
     const char* name;

--- a/resources/sugarcrm/sugarcrmresource.cpp
+++ b/resources/sugarcrm/sugarcrmresource.cpp
@@ -61,8 +61,8 @@
 #include <KContacts/Addressee>
 
 #include <QDebug>
-#include <KLocale>
 
+#include <KLocalizedString>
 #include <KWindowSystem>
 
 #include <QtDBus/QDBusConnection>


### PR DESCRIPTION
Remaining uses detected by script:
./client/src/utilities/linkeditemsrepository.cpp:#define kDebug() qCDebug(FATCRM_CLIENT_LOG)
./client/src/utilities/linkeditemsrepository.cpp:            kDebug() << "Removing note at" << idx;
./client/src/utilities/linkeditemsrepository.cpp:            kDebug() << "Removing note at" << idx;
./client/src/utilities/linkeditemsrepository.cpp:            kDebug() << "Removing email at" << idx;
./client/src/utilities/linkeditemsrepository.cpp:            kDebug() << "Removing email at" << idx;
^ false-positive (kDebug is a define)

./resources/sugarcrm/taskshandler.cpp:#include <KDateTime>
./resources/sugarcrm/taskshandler.cpp:    todo.setCreated( KDateTime::fromString(value, QStringLiteral("%Y-%m-%d %H:%M:%S")) );
./resources/sugarcrm/taskshandler.cpp:    KDateTime dateDue = todo.dtDue();
./resources/sugarcrm/taskshandler.cpp:    todo.setDtDue( KDateTime::fromString( value, QStringLiteral("%Y-%m-%d %H:%M:%S"), nullptr, true ) );
./resources/sugarcrm/taskshandler.cpp:    KDateTime dateStart = todo.dtStart();
./resources/sugarcrm/taskshandler.cpp:    todo.setDtStart( KDateTime::fromString( value, QStringLiteral("%Y-%m-%d %H:%M:%S"), nullptr, true ) );
^ required b/c we use KDateTime in KCalCore API

./resources/salesforce/salesforceresource.cpp:    KUrl url(host);
^ commented code