### PR TITLE
Fallback sort

### DIFF
--- a/client/src/models/opportunityfilterproxymodel.cpp
+++ b/client/src/models/opportunityfilterproxymodel.cpp
@@ -173,7 +173,7 @@ bool OpportunityFilterProxyModel::lessThan(const QModelIndex &left, const QModel
         return false;
     }
 
-    // fallback the values are equal
+    // fallback if the values are equal
     const ItemsTreeModel::ColumnTypes columns = ItemsTreeModel::columnTypes(Opportunity);
     const int nextStepDateColumn = columns.indexOf(ItemsTreeModel::NextStepDate);
     const int newSortColumn = (sortColumn() == nextStepDateColumn ?

--- a/client/src/models/opportunityfilterproxymodel.cpp
+++ b/client/src/models/opportunityfilterproxymodel.cpp
@@ -183,5 +183,21 @@ bool OpportunityFilterProxyModel::lessThan(const QModelIndex &left, const QModel
             return leftDt < rightDt;
         }
     }
-    return FilterProxyModel::lessThan(left, right);
+
+    if (FilterProxyModel::lessThan(left, right)) {
+        return true;
+    } else {
+        QVariant l = (left.model() ? left.model()->data(left, sortRole()) : QVariant());
+        QVariant r = (right.model() ? right.model()->data(right, sortRole()) : QVariant());
+
+        // if itens are equal sort by creation date
+        if (l == r) {
+            const int lastModifiedDateColumn = columns.indexOf(ItemsTreeModel::CreationDate);
+            QDate leftDt = left.sibling(left.row(), lastModifiedDateColumn).data(sortRole()).toDate();
+            QDate rightDt = right.sibling(right.row(), lastModifiedDateColumn).data(sortRole()).toDate();
+            return leftDt < rightDt;
+        } else {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
If items data on sortColumn are equal use creation data as fallback to
determine item sort order

This will avoid items changing position on the list after edit it