### PR TITLE
Allow the user to choose a default resource

### DIFF
--- a/client/src/app/clientsettings.cpp
+++ b/client/src/app/clientsettings.cpp
@@ -137,6 +137,16 @@ ClientSettings::GroupFilters ClientSettings::countryFilters() const
     return ret;
 }
 
+QString ClientSettings::defaultResourceId() const
+{
+    return m_settings->value(QStringLiteral("defaultResourceId"), QString()).toString();
+}
+
+void ClientSettings::setDefaultResourceId(const QString &id)
+{
+    m_settings->setValue(QStringLiteral("defaultResourceId"), id);
+}
+
 QString ClientSettings::GroupFilters::toString() const
 {
     QString ret;

--- a/client/src/app/clientsettings.h
+++ b/client/src/app/clientsettings.h
@@ -86,6 +86,9 @@ public:
     void setCountryFilters(const GroupFilters &filters);
     GroupFilters countryFilters() const;
 
+    void setDefaultResourceId(const QString &id);
+    QString defaultResourceId() const;
+
     ClientSettings();
     ~ClientSettings();
 

--- a/client/src/app/mainwindow.cpp
+++ b/client/src/app/mainwindow.cpp
@@ -686,16 +686,12 @@ void MainWindow::initialResourceSelection()
         mLoadingOverlay->setMessage(i18n("Configure a SugarCRM resource in order to use FatCRM."));
         showResourceDialog();
     } else {
-        QString defaultResourceId = ClientSettings::self()->defaultResourceId();
-        if (!defaultResourceId.isEmpty()) {
-            for (int index = 0; index < mResourceSelector->count(); ++index) {
-                const AgentInstance agent = mResourceSelector->itemData(index, AgentInstanceModel::InstanceRole).value<AgentInstance>();
-                if (agent.isValid() && (agent.identifier() == defaultResourceId)) {
-                    slotResourceSelectionChanged(index);
-                    mResourceDialog->hide();
-                    return;
-                }
-            }
+        const int resourceIndex = resourceIndexFor(ClientSettings::self()->defaultResourceId());
+        if (resourceIndex != -1) {
+            mResourceSelector->setCurrentIndex(resourceIndex);
+            slotResourceSelectionChanged(resourceIndex);
+            mResourceDialog->hide();
+            return;
         }
 
         mResourceSelector->setCurrentIndex(-1);
@@ -710,6 +706,21 @@ void MainWindow::showResourceDialog()
     // delay mResourceDialog->raise() so it happens after MainWindow::show() (from main.cpp)
     // This is part of the "mResourceDialog has no parent" workaround
     QMetaObject::invokeMethod(mResourceDialog, "raise", Qt::QueuedConnection);
+}
+
+int MainWindow::resourceIndexFor(const QString &id) const
+{
+    if (id.isEmpty())
+        return -1;
+
+    for (int index = 0; index < mResourceSelector->count(); ++index) {
+        const AgentInstance agent = mResourceSelector->itemData(index, AgentInstanceModel::InstanceRole).value<AgentInstance>();
+        if (agent.isValid() && (agent.identifier() == id)) {
+            return index;
+        }
+    }
+
+    return -1;
 }
 
 Page *MainWindow::pageForType(DetailsType type) const

--- a/client/src/app/mainwindow.cpp
+++ b/client/src/app/mainwindow.cpp
@@ -134,7 +134,7 @@ void MainWindow::slotDelayedInit()
     mResourceDialog = new ResourceConfigDialog;
 
     connect(mResourceDialog, SIGNAL(resourceSelected(Akonadi::AgentInstance)),
-            this, SLOT(slotResourceSelected(Akonadi::AgentInstance)));
+            this, SLOT(slotDialogResourceSelected(Akonadi::AgentInstance)));
 
     connect(mCollectionManager, SIGNAL(collectionResult(QString,Akonadi::Collection)),
             this, SLOT(slotCollectionResult(QString,Akonadi::Collection)));
@@ -257,7 +257,6 @@ void MainWindow::slotResourceSelectionChanged(int index)
     }
     AgentInstance agent = mResourceSelector->itemData(index, AgentInstanceModel::InstanceRole).value<AgentInstance>();
     if (agent.isValid()) {
-        ClientSettings::self()->setDefaultResourceId(agent.identifier());
         const QByteArray identifier = agent.identifier().toLatin1();
         emit resourceSelected(identifier);
         slotResourceOnline(agent, agent.isOnline());
@@ -288,6 +287,12 @@ void MainWindow::slotResourceSelected(const Akonadi::AgentInstance &resource)
             return;
         }
     }
+}
+
+void MainWindow::slotDialogResourceSelected(const AgentInstance &resource)
+{
+    ClientSettings::self()->setDefaultResourceId(resource.identifier());
+    slotResourceSelected(resource);
 }
 
 void MainWindow::slotServerStarted()

--- a/client/src/app/mainwindow.cpp
+++ b/client/src/app/mainwindow.cpp
@@ -257,6 +257,7 @@ void MainWindow::slotResourceSelectionChanged(int index)
     }
     AgentInstance agent = mResourceSelector->itemData(index, AgentInstanceModel::InstanceRole).value<AgentInstance>();
     if (agent.isValid()) {
+        ClientSettings::self()->setDefaultResourceId(agent.identifier());
         const QByteArray identifier = agent.identifier().toLatin1();
         emit resourceSelected(identifier);
         slotResourceOnline(agent, agent.isOnline());
@@ -680,6 +681,18 @@ void MainWindow::initialResourceSelection()
         mLoadingOverlay->setMessage(i18n("Configure a SugarCRM resource in order to use FatCRM."));
         showResourceDialog();
     } else {
+        QString defaultResourceId = ClientSettings::self()->defaultResourceId();
+        if (!defaultResourceId.isEmpty()) {
+            for (int index = 0; index < mResourceSelector->count(); ++index) {
+                const AgentInstance agent = mResourceSelector->itemData(index, AgentInstanceModel::InstanceRole).value<AgentInstance>();
+                if (agent.isValid() && (agent.identifier() == defaultResourceId)) {
+                    slotResourceSelectionChanged(index);
+                    mResourceDialog->hide();
+                    return;
+                }
+            }
+        }
+
         mResourceSelector->setCurrentIndex(-1);
         mLoadingOverlay->setMessage(i18n("Choose a SugarCRM resource."));
         showResourceDialog();

--- a/client/src/app/mainwindow.h
+++ b/client/src/app/mainwindow.h
@@ -75,6 +75,7 @@ private Q_SLOTS:
     void slotFullReload();
     void slotResourceSelectionChanged(int index);
     void slotResourceSelected(const Akonadi::AgentInstance &resource);
+    void slotDialogResourceSelected(const Akonadi::AgentInstance &resource);
     void slotResourceCountChanged();
     void slotServerStarted();
     void slotShowMessage(const QString &);

--- a/client/src/app/mainwindow.h
+++ b/client/src/app/mainwindow.h
@@ -115,6 +115,7 @@ private:
     void initialLoadingDone();
     void processPendingImports();
     void showResourceDialog();
+    int resourceIndexFor(const QString &id) const;
 
     QList<Page *> mPages;
 

--- a/client/src/dialogs/resourceconfigdialog.ui
+++ b/client/src/dialogs/resourceconfigdialog.ui
@@ -15,6 +15,20 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
+    <widget class="QLabel" name="title">
+     <property name="font">
+      <font>
+       <pointsize>10</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Select the resource that should be used on startup</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="Akonadi::AgentInstanceWidget" name="resources">


### PR DESCRIPTION
On app startup check for pre-selected resource to avoid ask for pick a
new one.

To choose a different resource the user can go on "File->CRM Accounts" and
choose a new one.