### PR TITLE
Fixed document removal on Opportunity details page

### DIFF
--- a/client/src/dialogs/documentswindow.cpp
+++ b/client/src/dialogs/documentswindow.cpp
@@ -265,11 +265,7 @@ void DocumentsWindow::deleteDocument()
     if (answer == QMessageBox::No)
         return;
 
-    auto it = std::find_if(mDocuments.constBegin(), mDocuments.constEnd(), [&documentId](const SugarDocument &document) { return document.id() == documentId; });
-    if (it != mDocuments.constEnd()) {
-        mDocuments.remove(std::distance(mDocuments.constBegin(), it));
-    }
-
+    // Remove the document from the view (mDocumentWidgets). Keep in mDocuments so that saveChanges() sees it and triggers deletion.
     mDocumentWidgets.remove(mDocumentWidgets.indexOf(widget));
 
     widget->deleteLater();

--- a/client/src/utilities/linkeditemsrepository.cpp
+++ b/client/src/utilities/linkeditemsrepository.cpp
@@ -169,6 +169,7 @@ void LinkedItemsRepository::removeNote(const QString &id)
             const int idx = std::distance(notes.constBegin(), it);
             kDebug() << "Removing note at" << idx;
             notes.remove(idx);
+            emit accountModified(oldAccountId);
         }
     }
 
@@ -182,6 +183,7 @@ void LinkedItemsRepository::removeNote(const QString &id)
             const int idx = std::distance(notes.constBegin(), it);
             kDebug() << "Removing note at" << idx;
             notes.remove(idx);
+            emit contactModified(oldContactId);
         }
     }
 
@@ -195,6 +197,7 @@ void LinkedItemsRepository::removeNote(const QString &id)
             const int idx = std::distance(notes.constBegin(), it);
             qDebug() << "Removing note at" << idx;
             notes.remove(idx);
+            emit opportunityModified(oldOpportunityId);
         }
     }
 }
@@ -323,6 +326,7 @@ void LinkedItemsRepository::removeEmail(const QString &id)
             const int idx = std::distance(emails.constBegin(), it);
             kDebug() << "Removing email at" << idx;
             emails.remove(idx);
+            emit accountModified(oldAccountId);
         }
     }
 
@@ -336,6 +340,7 @@ void LinkedItemsRepository::removeEmail(const QString &id)
             const int idx = std::distance(emails.constBegin(), it);
             kDebug() << "Removing email at" << idx;
             emails.remove(idx);
+            emit contactModified(oldContactId);
         }
     }
 
@@ -349,6 +354,7 @@ void LinkedItemsRepository::removeEmail(const QString &id)
             const int idx = std::distance(emails.constBegin(), it);
             qDebug() << "Removing email at" << idx;
             emails.remove(idx);
+            emit opportunityModified(oldOpportunityId);
         }
     }
 }
@@ -446,6 +452,7 @@ void LinkedItemsRepository::removeDocument(const QString &id)
             const int idx = std::distance(documents.constBegin(), it);
             qCWarning(FATCRM_CLIENT_LOG) << "Removing document at" << idx;
             documents.remove(idx);
+            emit accountModified(oldLinkedAccountId);
         }
     }
 
@@ -457,6 +464,7 @@ void LinkedItemsRepository::removeDocument(const QString &id)
             const int idx = std::distance(documents.constBegin(), it);
             qCWarning(FATCRM_CLIENT_LOG) << "Removing document at" << idx;
             documents.remove(idx);
+            emit opportunityModified(oldLinkedOpportunityId);
         }
     }
 


### PR DESCRIPTION
Does not remove documents from Opportunity until the save buttom is
pressed

Make sure that the signal:
 'LinkedItemsRepository::opportunityModified'
 'LinkedItemsRepository::contactModified'
 'LinkedItemsRepository::accountModified'

Is fired on email/note/document removal.