### PR TITLE
Trigger a new sync after attach a document

### DIFF
--- a/client/src/app/mainwindow.cpp
+++ b/client/src/app/mainwindow.cpp
@@ -244,6 +244,7 @@ void MainWindow::setupActions()
                 this, SLOT(slotModelLoaded(DetailsType)));
         connect(page, SIGNAL(synchronizeCollection(Akonadi::Collection)),
                 this, SLOT(slotSynchronizeCollection(Akonadi::Collection)));
+        connect(page, &Page::syncRequired, this, &MainWindow::slotSynchronize);
         connect(page, SIGNAL(openObject(DetailsType,QString)),
                 this, SLOT(slotOpenObject(DetailsType,QString)));
     }

--- a/client/src/details/accountdetails.cpp
+++ b/client/src/details/accountdetails.cpp
@@ -153,7 +153,8 @@ void AccountDetails::on_viewDocumentsButton_clicked()
 {
     const QString accountId = id();
 
-    auto *dlg = new DocumentsWindow(nullptr);
+    DocumentsWindow *dlg = new DocumentsWindow(nullptr);
+    connect(dlg, &DocumentsWindow::documentsCreated, this, &AccountDetails::syncRequired);
     dlg->setWindowTitle(i18n("Documents for account %1", name()));
 
     dlg->setResourceIdentifier(resourceIdentifier());

--- a/client/src/details/details.h
+++ b/client/src/details/details.h
@@ -75,6 +75,7 @@ public:
 Q_SIGNALS:
     void modified();
     void openObject(DetailsType type, const QString &id);
+    void syncRequired();
 
 protected:
     QByteArray resourceIdentifier() const { return mResourceIdentifier; }

--- a/client/src/details/opportunitydetails.cpp
+++ b/client/src/details/opportunitydetails.cpp
@@ -234,7 +234,8 @@ void OpportunityDetails::on_viewDocumentsButton_clicked()
 {
     const QString oppId = id();
 
-    auto *dlg = new DocumentsWindow(nullptr);
+    DocumentsWindow *dlg = new DocumentsWindow(nullptr);
+    connect(dlg, &DocumentsWindow::documentsCreated, this, &OpportunityDetails::syncRequired);
     dlg->setWindowTitle(i18n("Documents for opportunity %1", name()));
 
     dlg->setResourceIdentifier(resourceIdentifier());
@@ -285,3 +286,4 @@ void OpportunityDetails::setItemsTreeModel(ItemsTreeModel *model)
     mUi->next_step->setCompleter(nextStepCompleter);
     Details::setItemsTreeModel(model);
 }
+

--- a/client/src/dialogs/documentswindow.cpp
+++ b/client/src/dialogs/documentswindow.cpp
@@ -364,6 +364,7 @@ void DocumentsWindow::saveChanges()
 
     const auto service = Akonadi::ServerManager::agentServiceName(Akonadi::ServerManager::Resource,
                                                                   mResourceIdentifier);
+    bool docsCreated = false;
     foreach (DocumentWidget *widget, mDocumentWidgets) {
         if (widget->isModified()) {
             const SugarDocument document = widget->document();
@@ -407,6 +408,7 @@ void DocumentsWindow::saveChanges()
                     continue;
                 }
 
+                docsCreated = true;
             } else {
                 Akonadi::Item item = mLinkedItemsRepository->documentItem(document.id());
                 if (item.isValid()) {
@@ -419,6 +421,10 @@ void DocumentsWindow::saveChanges()
                 }
             }
         }
+    }
+
+    if (docsCreated) {
+        emit documentsCreated();
     }
 
     if (mPendingJobCount == 0 && errors == 0) {

--- a/client/src/dialogs/documentswindow.h
+++ b/client/src/dialogs/documentswindow.h
@@ -90,6 +90,9 @@ public:
 
     void loadDocumentsFor(const QString &id, LinkedItemType itemType);
 
+signals:
+    void documentsCreated();
+
 protected:
     void closeEvent(QCloseEvent *event) override;
 

--- a/client/src/pages/page.cpp
+++ b/client/src/pages/page.cpp
@@ -630,6 +630,7 @@ ItemEditWidgetBase *Page::createItemEditWidget(const Akonadi::Item &item, Detail
 
     connect(details, SIGNAL(openObject(DetailsType,QString)),
             this, SIGNAL(openObject(DetailsType,QString)));
+    connect(details, &Details::syncRequired, this, &Page::syncRequired);
     // Don't set a parent, so that the widgets can be minimized/restored independently
     auto *widget = new SimpleItemEditWidget(details);
     widget->setOnline(mOnline);

--- a/client/src/pages/page.h
+++ b/client/src/pages/page.h
@@ -74,6 +74,7 @@ Q_SIGNALS:
     void modelLoaded(DetailsType type);
     void modelItemChanged(const Akonadi::Item &item);
     void synchronizeCollection(const Akonadi::Collection &collection);
+    void syncRequired();
     void openObject(DetailsType type, const QString &id);
     void onlineStatusChanged(bool online);
 


### PR DESCRIPTION
* For design decisions we do not create an Akonadi object at the moment that the user attach a new doc.  Because of that we need to sync to make this document to available on client side.


Fixes: FATCRM-184