### PR TITLE
sugarcrm: Use lower-case ids for link_field_name

### DIFF
--- a/resources/sugarcrm/documentshandler.cpp
+++ b/resources/sugarcrm/documentshandler.cpp
@@ -153,7 +153,7 @@ void DocumentsHandler::getExtraInformation(Akonadi::Item::List &items)
         // Get the Account(s) related to this document
         // http://support.sugarcrm.com/Documentation/Sugar_Developer/Sugar_Developer_Guide_6.5/Application_Framework/Web_Services/Method_Calls/get_relationships/
         // http://support.sugarcrm.com/Documentation/Sugar_Developer/Sugar_Developer_Guide_6.5/Application_Framework/Web_Services/Examples/REST/PHP/Retrieving_Related_Records/
-        KDSoapGenerated::TNS__Get_entry_result_version2 result = soap()->get_relationships(sessionId(), QStringLiteral("Documents"), document.id(), QStringLiteral("Accounts"), {}, {},
+        KDSoapGenerated::TNS__Get_entry_result_version2 result = soap()->get_relationships(sessionId(), QStringLiteral("Documents"), document.id(), moduleToName(Module::Accounts).toLower(), {}, {},
                                                                    {}, 0 /*deleted*/, QString(), 0 /*offset*/, 0 /*limit*/);
 
         QStringList linkedAccountIds;
@@ -167,8 +167,9 @@ void DocumentsHandler::getExtraInformation(Akonadi::Item::List &items)
         }
 
         QStringList linkedOpportunityIds;
-        result = soap()->get_relationships(sessionId(), QStringLiteral("Documents"), document.id(), QStringLiteral("Opportunities"), {}, {},
+        result = soap()->get_relationships(sessionId(), QStringLiteral("Documents"), document.id(), moduleToName(Module::Opportunities).toLower(), {}, {},
                                            {}, 0 /*deleted*/, QString(), 0 /*offset*/, 0 /*limit*/);
+
         Q_FOREACH (const KDSoapGenerated::TNS__Entry_value &entry, result.entry_list().items()) {
             linkedOpportunityIds.append(entry.id());
         }

--- a/resources/sugarcrm/tests/test_jobwithsugarsoapprotocol.cpp
+++ b/resources/sugarcrm/tests/test_jobwithsugarsoapprotocol.cpp
@@ -376,7 +376,6 @@ private Q_SLOTS:
             QVERIFY2(!deletedDocumentNames.contains("MyDocument"), qPrintable(deletedDocumentNames.join(',')));
 
             QCOMPARE(newDocuments.count(), 1);
-            QEXPECT_FAIL("", "This is broken...", Continue);
             QCOMPARE(newDocuments.at(0).linkedOpportunityIds().count(), 1);
         }
 


### PR DESCRIPTION
Fixes the shouldAttachDocument test function