### PR TITLE
Fix CMake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,6 @@ endif()
 if(POLICY CMP0063)
   cmake_policy(SET CMP0063 NEW)
 endif()
-if(POLICY CMP0059)
-  cmake_policy(SET CMP0059 OLD) # we use DEFINITIONS as a built-in directory property
-endif()
 
 # we need some parts of the ECM CMake helpers
 find_package(ECM 5.12.0 REQUIRED NO_MODULE)


### PR DESCRIPTION
I'm not sure why this was set to OLD in the first place

Fixes:
```
CMake Deprecation Warning at CMakeLists.txt:11 (cmake_policy):
  The OLD behavior for policy CMP0059 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
```