### PR TITLE
Automated reporting

### DIFF
--- a/client/src/app/clientsettings.cpp
+++ b/client/src/app/clientsettings.cpp
@@ -256,6 +256,16 @@ void ClientSettings::loadSavedSearch(OpportunityFilterSettings &settings, const 
     settings.load(*m_settings, prefix);
 }
 
+const QSettings &ClientSettings::settings() const
+{
+    return *m_settings;
+}
+
+QSettings &ClientSettings::settings()
+{
+    return *m_settings;
+}
+
 QVector<QString> ClientSettings::savedSearches() const
 {
     return OpportunityFilterSettings::savedSearches(*m_settings);

--- a/client/src/app/clientsettings.h
+++ b/client/src/app/clientsettings.h
@@ -23,18 +23,21 @@
 #ifndef CLIENTSETTINGS_H
 #define CLIENTSETTINGS_H
 
+#include "fatcrmprivate_export.h"
+
 #include <QObject>
-class QSettings;
-class OpportunityFilterSettings;
 #include <QSize>
 #include <QStringList>
 #include <QVector>
+
+class QSettings;
+class OpportunityFilterSettings;
 
 /**
  * Settings for the FatCRM client application.
  * Saved in ~/.config/KDAB/FatCRM.conf
  */
-class ClientSettings : public QObject
+class FATCRMPRIVATE_EXPORT ClientSettings : public QObject
 {
     Q_OBJECT
 public:
@@ -62,6 +65,9 @@ public:
 
     void saveSearch(const OpportunityFilterSettings &settings, QString searchName);
     void loadSavedSearch(OpportunityFilterSettings &settings, const QString &prefix);
+
+    const QSettings &settings() const;
+    QSettings& settings();
 
     class GroupFilters
     {

--- a/client/src/app/mainwindow.cpp
+++ b/client/src/app/mainwindow.cpp
@@ -620,7 +620,6 @@ void MainWindow::slotPrintReport()
     KDReports::PreviewDialog preview(report.get(), this);
     preview.setWindowTitle(i18n("Print Preview"));
     preview.previewWidget()->setShowPageListWidget(false);
-    preview.previewWidget()->setShowTableSettingsDialog(false);
     preview.resize(1167, 906);
     preview.exec();
 }

--- a/client/src/app/mainwindow.h
+++ b/client/src/app/mainwindow.h
@@ -60,11 +60,19 @@ public:
 
     ~MainWindow() override;
 
+    Page *currentPage() const;
+    Page *pageForType(DetailsType type) const;
+
     bool eventFilter(QObject *object, QEvent *event) override;
+
+public Q_SLOTS:
+    bool loadSavedSearch(const QString &searchName);
 
 Q_SIGNALS:
     void resourceSelected(const QByteArray &identifier);
     void onlineStatusChanged(bool online);
+
+    void initialLoadingDone();
 
 protected:
     void closeEvent(QCloseEvent *event) override;
@@ -114,17 +122,14 @@ private:
     void addPage(Page *page);
     void updateWindowTitle(bool online);
 
-    Page *currentPage() const;
-    Page *pageForType(DetailsType type) const;
     void setupResourcesCombo();
     Akonadi::AgentInstance currentResource() const;
     void initialResourceSelection();
-    void initialLoadingDone();
+    void slotInitialLoadingDone();
     void processPendingImports();
     void showResourceDialog();
     int resourceIndexFor(const QString &id) const;
     void raiseMainWindowAndDialog(QWidget *dialog);
-    void loadSavedSearch(const QString &selectedItemName);
 
     QList<Page *> mPages;
 

--- a/client/src/pages/page.cpp
+++ b/client/src/pages/page.cpp
@@ -47,6 +47,8 @@
 #include "kdcrmdata/sugarcampaign.h"
 #include "kdcrmdata/sugarlead.h"
 
+#include <KDReportsReport.h>
+
 #include <AkonadiCore/AgentManager>
 #include <AkonadiCore/ChangeRecorder>
 #include <AkonadiCore/CollectionStatistics>
@@ -589,12 +591,12 @@ void Page::slotItemSaved()
     emit statusMessage(QStringLiteral("Item successfully saved"));
 }
 
-void Page::printReport()
+std::unique_ptr<KDReports::Report> Page::generateReport(bool warnOnLongReport) const
 {
-    ReportGenerator generator;
     QAbstractItemModel *model = mUi.treeView->model();
     if (!model)
-        return;
+        return {};
+
     const int count = model->rowCount();
     if (count > 1000) {
         QMessageBox msgBox;
@@ -606,7 +608,7 @@ void Page::printReport()
         msgBox.setDefaultButton(QMessageBox::Yes);
         int ret = msgBox.exec();
         if (ret == QMessageBox::Cancel) {
-            return;
+            return {};
         }
     }
 
@@ -628,7 +630,8 @@ void Page::printReport()
     rearrangeColumnsProxy.setSourceColumns(sourceColumns);
     rearrangeColumnsProxy.setSourceModel(&createLinksProxy);
 
-    generator.generateListReport(&rearrangeColumnsProxy, reportTitle(), reportSubTitle(count), this);
+    ReportGenerator generator;
+    return generator.generateListReport(&rearrangeColumnsProxy, reportTitle(), reportSubTitle(count));
 }
 
 ItemEditWidgetBase *Page::createItemEditWidget(const Akonadi::Item &item, DetailsType itemType, bool forceSimpleWidget)

--- a/client/src/pages/page.h
+++ b/client/src/pages/page.h
@@ -23,8 +23,10 @@
 #ifndef PAGE_H
 #define PAGE_H
 
+#include "fatcrmprivate_export.h"
 #include "enums.h"
 #include "filterproxymodel.h"
+#include "reportgenerator.h"
 #include "ui_page.h"
 
 #include "kdcrmdata/enumdefinitions.h"
@@ -33,6 +35,10 @@
 #include <AkonadiCore/Item>
 
 #include <QWidget>
+
+namespace KDReports {
+class Report;
+}
 
 namespace Akonadi
 {
@@ -49,7 +55,7 @@ class KJobProgressTracker;
 class LinkedItemsRepository;
 class QPoint;
 
-class Page : public QWidget
+class FATCRMPRIVATE_EXPORT Page : public QWidget
 {
     Q_OBJECT
 public:
@@ -66,7 +72,7 @@ public:
     LinkedItemsRepository *linkedItemsRepository() const;
     bool queryClose();
     void openWidget(const QString &id);
-    void printReport();
+    Q_REQUIRED_RESULT std::unique_ptr<KDReports::Report> generateReport(bool warnOnLongReport = true) const;
     void createNewItem(const QMap<QString, QString> &data = QMap<QString, QString>());
     void setSearchText(const QString &searchText);
     QString searchText() const { return mUi.searchLE->text(); }

--- a/client/src/reports/reportgenerator.cpp
+++ b/client/src/reports/reportgenerator.cpp
@@ -21,16 +21,19 @@
 */
 
 #include "reportgenerator.h"
+
 #include <KDReportsReport.h>
 #include <KDReportsHeader.h>
 #include <KDReportsTextElement.h>
 #include <KDReportsAutoTableElement.h>
-#include <KDReportsPreviewDialog.h>
-#include <KDReportsPreviewWidget.h>
 
 #include <KLocalizedString>
 
 ReportGenerator::ReportGenerator()
+{
+}
+
+ReportGenerator::~ReportGenerator()
 {
 }
 
@@ -73,34 +76,25 @@ void ReportGenerator::addHeader(KDReports::Report &report)
     header.addVariable(KDReports::PageCount);
 }
 
-void ReportGenerator::generateListReport(QAbstractItemModel *model, const QString &title,
-                                         const QString &subTitle, QWidget *parent)
+std::unique_ptr<KDReports::Report> ReportGenerator::generateListReport(QAbstractItemModel *model, const QString &title,
+                                         const QString &subTitle)
 {
-    KDReports::Report report;
-    setupReport(report);
-    addTitle(report, title);
-    addSubTitle(report, subTitle);
+    auto report = std::unique_ptr<KDReports::Report>(new KDReports::Report);
 
-    report.addVerticalSpacing(5);
+    setupReport(*report);
+    addTitle(*report, title);
+    addSubTitle(*report, subTitle);
 
-    report.setParagraphMargins(1, 1, 1, 1);
+    report->addVerticalSpacing(5);
+
+    report->setParagraphMargins(1, 1, 1, 1);
     KDReports::AutoTableElement table(model);
     table.setVerticalHeaderVisible(false);
     // make sure country flags do not get huge
     table.setIconSize(QSize(16, 16));
-    report.addElement(table);
+    report->addElement(table);
 
-    finalizeReport(report, parent);
-}
+    report->setPageSize(QPrinter::A4);
 
-void ReportGenerator::finalizeReport(KDReports::Report &report, QWidget *parent)
-{
-    report.setPageSize(QPrinter::A4);
-
-    KDReports::PreviewDialog preview(&report, parent);
-    preview.setWindowTitle(i18n("Print Preview"));
-    preview.previewWidget()->setShowPageListWidget(false);
-    preview.previewWidget()->setShowTableSettingsDialog(false);
-    preview.resize(1167, 906);
-    preview.exec();
+    return report;
 }

--- a/client/src/reports/reportgenerator.h
+++ b/client/src/reports/reportgenerator.h
@@ -23,26 +23,32 @@
 #ifndef REPORTGENERATOR_H
 #define REPORTGENERATOR_H
 
-class QAbstractItemModel;
+#include "fatcrmprivate_export.h"
+
+#include <qglobal.h>
+
+#include <memory>
+
 namespace KDReports {
     class Report;
 }
-class QString;
-class QWidget;
 
-class ReportGenerator
+class QAbstractItemModel;
+class QString;
+
+class FATCRMPRIVATE_EXPORT ReportGenerator
 {
 public:
     ReportGenerator();
+    ~ReportGenerator();
 
-    void generateListReport(QAbstractItemModel *model, const QString &title, const QString &subTitle, QWidget *parent);
+    Q_REQUIRED_RESULT std::unique_ptr<KDReports::Report> generateListReport(QAbstractItemModel *model, const QString &title, const QString &subTitle);
 
 private:
     void setupReport(KDReports::Report &report);
     void addHeader(KDReports::Report &report);
     void addTitle(KDReports::Report &report, const QString &title);
     void addSubTitle(KDReports::Report &report, const QString &text);
-    void finalizeReport(KDReports::Report &report, QWidget *parent);
 };
 
 #endif // REPORTGENERATOR_H

--- a/client/src/utilities/enums.cpp
+++ b/client/src/utilities/enums.cpp
@@ -41,6 +41,17 @@ QString typeToString(DetailsType type)
     return QString();
 }
 
+DetailsType stringToType(const QString &typeStr)
+{
+    static const QVector<QString> types = {"Accounts", "Opportunities", "Leads", "Contacts", "Campaigns"};
+
+    const int index = types.indexOf(typeStr);
+    if (index == -1)
+        return DetailsType::Account; // default
+
+    return static_cast<DetailsType>(index);
+}
+
 QString typeToTranslatedString(DetailsType type)
 {
     switch (type) {

--- a/client/src/utilities/enums.h
+++ b/client/src/utilities/enums.h
@@ -23,6 +23,8 @@
 #ifndef ENUMS_H
 #define ENUMS_H
 
+#include "fatcrmprivate_export.h"
+
 #include <QString>
 #include <QMetaType>
 
@@ -35,8 +37,9 @@ enum class DetailsType {
 };
 static const int MaxType = int(DetailsType::Campaign);
 
-QString typeToString(DetailsType type);
-QString typeToTranslatedString(DetailsType type);
+FATCRMPRIVATE_EXPORT QString typeToString(DetailsType type);
+FATCRMPRIVATE_EXPORT DetailsType stringToType(const QString &typeStr);
+FATCRMPRIVATE_EXPORT QString typeToTranslatedString(DetailsType type);
 
 enum ReferencedDataType {
     AccountRef,        // account.id()     => account.name()


### PR DESCRIPTION
    Allow to print reports from command-line
    
    This can be used to quickly create reports. In combination with being
    able to quickly change the saved searches using the command-line one can
    automatically create reports e.g. after each work day.
    
    Example invocation:
      fatcrm --config-key savedSearch-1/modifiedBefore --set-config-value 2019-07-02
      fatcrm --config-key savedSearch-1/modifiedAfter --set-config-value 2019-07-02
      fatcrm --load-saved-search "Opportunities changed today" --print-to-pdf ~/out.pdf
    
     (first modify the saved search, then load and print it)