### PR TITLE
models: See which opps are 'warm'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ endif()
 
 find_package(KF5Contacts ${KCONTACTS_LIB_VERSION} CONFIG REQUIRED)
 find_package(KF5AkonadiContact CONFIG REQUIRED)
+find_package(KF5GuiAddons CONFIG REQUIRED)
 find_package(KF5I18n CONFIG REQUIRED)
 find_package(KF5KIO CONFIG REQUIRED)
 find_package(KF5IconThemes CONFIG REQUIRED)

--- a/client/src/CMakeLists.txt
+++ b/client/src/CMakeLists.txt
@@ -135,6 +135,7 @@ target_link_libraries(fatcrmprivate
   KF5::AkonadiWidgets
   KF5::Contacts
   KF5::DBusAddons
+  KF5::GuiAddons
   KF5::KIOWidgets
   KF5::WidgetsAddons
   Qt5::PrintSupport

--- a/client/src/models/itemstreemodel.h
+++ b/client/src/models/itemstreemodel.h
@@ -139,6 +139,8 @@ private Q_SLOTS:
     void slotAccountModified(const QString &accountId, const QVector<AccountRepository::Field> &changedFields);
     void slotAccountRemoved(const QString &accountId);
     void slotAccountsLoaded();
+    void updateBackgrounds();
+    void updateBackgrounds(int first, int last);
 
 private:
     QVariant accountData(const Akonadi::Item &item, int column, int role) const;


### PR DESCRIPTION
Indicate whether we are past a next step date or whether we recently
updated the last modified date.

Try to do that in a performant way; calculating the background color on
the fly won't work since we'd have to ask for the current date time for
each row individual in that case. Thus create a cache in ItemsTreeModel where
we store the backgrounds for all rows.

Task-Id: FATCRM-109