### PR TITLE
opps: Allow filter "Closed Won" and "Closed Lost"

### DIFF
--- a/client/src/models/opportunityfilterproxymodel.cpp
+++ b/client/src/models/opportunityfilterproxymodel.cpp
@@ -160,10 +160,14 @@ bool OpportunityFilterProxyModel::filterAcceptsRow(int row, const QModelIndex &p
         }
     }
 
-    const bool isClosed = opportunity.salesStage().contains(QLatin1String("Closed"));
-    if (!d->settings.showClosed() && isClosed)
+    const auto salesStage = opportunity.salesStage();
+    const bool isClosedWon = salesStage.contains(QLatin1String("Closed Won"));
+    const bool isClosedLost = salesStage.contains(QLatin1String("Closed Lost"));
+    if (!d->settings.showClosedWon() && isClosedWon)
         return false;
-    if (!d->settings.showOpen() && !isClosed)
+    if (!d->settings.showClosedLost() && isClosedLost)
+        return false;
+    if (!d->settings.showOpen() && !isClosedWon && !isClosedLost)
         return false;
     if (d->settings.maxDate().isValid() && (!opportunity.nextCallDate().isValid()
                                  || opportunity.nextCallDate() > d->settings.maxDate()))

--- a/client/src/pages/opportunityfilterwidget.cpp
+++ b/client/src/pages/opportunityfilterwidget.cpp
@@ -57,7 +57,8 @@ OpportunityFilterWidget::OpportunityFilterWidget(OpportunityFilterProxyModel *op
     connect(ui->cbAssignee, SIGNAL(activated(QString)), this, SLOT(filterChanged()));
     connect(ui->cbMaxNextStepDate, SIGNAL(activated(QString)), this, SLOT(filterChanged()));
     connect(ui->cbOpen, &QAbstractButton::toggled, this, &OpportunityFilterWidget::filterChanged);
-    connect(ui->cbClosed, &QAbstractButton::toggled, this, &OpportunityFilterWidget::filterChanged);
+    connect(ui->cbClosedWon, &QAbstractButton::toggled, this, &OpportunityFilterWidget::filterChanged);
+    connect(ui->cbClosedLost, &QAbstractButton::toggled, this, &OpportunityFilterWidget::filterChanged);
     connect(ui->cbCountry, SIGNAL(activated(QString)), this, SLOT(slotCountrySelected()));
     connect(ui->cbCountry, SIGNAL(activated(QString)), this, SLOT(filterChanged()));
     connect(ui->modifiedAfter, &KDateComboBox::dateChanged, this, &OpportunityFilterWidget::filterChanged);
@@ -90,7 +91,8 @@ void OpportunityFilterWidget::setupFromConfig(const OpportunityFilterSettings &s
     }
     ui->cbCountry->setCurrentIndex(qMax(0, ui->cbCountry->findText(settings.countryGroup())));
     ui->cbOpen->setChecked(settings.showOpen());
-    ui->cbClosed->setChecked(settings.showClosed());
+    ui->cbClosedWon->setChecked(settings.showClosedWon());
+    ui->cbClosedLost->setChecked(settings.showClosedLost());
     if (settings.customMaxDate().isValid()) {
         ui->cbMaxNextStepDate->insertItem(CustomDate, settings.customMaxDate().toString(QStringLiteral("MM/d/yyyy")));
         mCustomMaxNextStepDate = settings.customMaxDate();
@@ -184,7 +186,7 @@ void OpportunityFilterWidget::filterChanged()
     }
     filterSettings.setAssignees(assignees, ui->cbAssignee->currentText());
     filterSettings.setCountries(countries, ui->cbCountry->currentText());
-    filterSettings.setShowOpenClosed(ui->cbOpen->isChecked(), ui->cbClosed->isChecked());
+    filterSettings.setShowOpenClosed(ui->cbOpen->isChecked(), ui->cbClosedWon->isChecked(), ui->cbClosedLost->isChecked());
     filterSettings.setModifiedAfter(ui->modifiedAfter->date());
     filterSettings.setModifiedBefore(ui->modifiedBefore->date());
     filterSettings.setCustomMaxDate(mCustomMaxNextStepDate);

--- a/client/src/pages/opportunityfilterwidget.ui
+++ b/client/src/pages/opportunityfilterwidget.ui
@@ -6,18 +6,84 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>819</width>
-    <height>126</height>
+    <width>974</width>
+    <height>138</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="1">
-    <widget class="QComboBox" name="cbCountry"/>
+   <item row="0" column="4" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Show:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="cbOpen">
+       <property name="text">
+        <string>Open</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="cbClosedWon">
+       <property name="text">
+        <string>Closed Won</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="cbClosedLost">
+       <property name="text">
+        <string>Closed Lost</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
-   <item row="1" column="5">
+   <item row="0" column="8">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Priority</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="6">
+    <widget class="NullableDateComboBox" name="modifiedAfter">
+     <property name="calendarPopup" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2" rowspan="3">
+    <widget class="Line" name="line">
+     <property name="minimumSize">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QRadioButton" name="rbAll">
+     <property name="text">
+      <string>A&amp;ll opportunities</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="6">
     <widget class="QComboBox" name="cbMaxNextStepDate">
      <item>
       <property name="text">
@@ -61,119 +127,20 @@
      </item>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QRadioButton" name="rbAssignedTo">
-     <property name="text">
-      <string>Assigned to</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="5">
-    <widget class="NullableDateComboBox" name="modifiedAfter">
-     <property name="calendarPopup" stdset="0">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="4">
-    <widget class="QCheckBox" name="cbOpen">
-     <property name="text">
-      <string>Open</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QRadioButton" name="rbCountry">
-     <property name="text">
-      <string>I&amp;n country</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="9">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
+   <item row="0" column="7">
+    <widget class="Line" name="line_2">
+     <property name="minimumSize">
       <size>
-       <width>40</width>
-       <height>20</height>
+       <width>20</width>
+       <height>0</height>
       </size>
      </property>
-    </spacer>
-   </item>
-   <item row="1" column="4">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Next step date before</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="3" rowspan="3">
-    <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
-    <spacer name="horizontalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Maximum</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>80</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="8">
-    <widget class="NullableDateComboBox" name="modifiedBefore">
-     <property name="calendarPopup" stdset="0">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="cbAssignee"/>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QRadioButton" name="rbAll">
-     <property name="text">
-      <string>A&amp;ll opportunities</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="5">
-    <widget class="QCheckBox" name="cbClosed">
-     <property name="text">
-      <string>Closed</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="4">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Last modified after</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="7" alignment="Qt::AlignHCenter">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>and before</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="8">
+   <item row="0" column="9">
     <widget class="QComboBox" name="cbPriority">
      <item>
       <property name="text">
@@ -202,10 +169,64 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="7">
-    <widget class="QLabel" name="label_4">
+   <item row="1" column="0">
+    <widget class="QRadioButton" name="rbAssignedTo">
      <property name="text">
-      <string>Show priority</string>
+      <string>Assigned to</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="9">
+    <widget class="NullableDateComboBox" name="modifiedBefore">
+     <property name="calendarPopup" stdset="0">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Next step date before</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="cbCountry"/>
+   </item>
+   <item row="2" column="4" colspan="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Last modified after</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="cbAssignee"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QRadioButton" name="rbCountry">
+     <property name="text">
+      <string>I&amp;n country</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="10">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="7" colspan="2">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>and before</string>
      </property>
     </widget>
    </item>

--- a/client/src/utilities/opportunityfiltersettings.cpp
+++ b/client/src/utilities/opportunityfiltersettings.cpp
@@ -65,10 +65,11 @@ void OpportunityFilterSettings::setModifiedBefore(const QDate &modifiedBefore)
     mModifiedBefore = modifiedBefore;
 }
 
-void OpportunityFilterSettings::setShowOpenClosed(bool showOpen, bool showClosed)
+void OpportunityFilterSettings::setShowOpenClosed(bool showOpen, bool showClosedWon, bool showClosedLost)
 {
     mShowOpen = showOpen;
-    mShowClosed = showClosed;
+    mShowClosedWon = showClosedWon;
+    mShowClosedLost = showClosedLost;
 }
 
 void OpportunityFilterSettings::setShownPriority(const QString &shownPriority)
@@ -88,11 +89,23 @@ void OpportunityFilterSettings::setSearchText(const QString &searchText)
 
 QString OpportunityFilterSettings::filterDescription() const
 {
+    auto appendWithSeparator = [](QString &out, const QString &str) {
+        if (!out.isEmpty()) {
+            out += ", ";
+        }
+        out += str;
+    };
+
     QString openOrClosed;
-    if (!mShowOpen && mShowClosed)
-        openOrClosed = i18n("closed");
-    else if (mShowOpen && !mShowClosed)
+    if (mShowOpen) {
         openOrClosed = i18n("open");
+    }
+    if (mShowClosedWon) {
+        appendWithSeparator(openOrClosed, i18n("closed won"));
+    }
+    if (mShowClosedLost) {
+        appendWithSeparator(openOrClosed, i18n("closed lost"));
+    }
 
     QString txt;
     if (!mAssignees.isEmpty()) {
@@ -141,7 +154,8 @@ void OpportunityFilterSettings::save(QSettings &settings, const QString &prefix)
     settings.setValue(prefix + "/modifiedBefore", mModifiedBefore);
     settings.setValue(prefix + "/modifiedAfter", mModifiedAfter);
     settings.setValue(prefix + "/showOpen", mShowOpen);
-    settings.setValue(prefix + "/showClosed", mShowClosed);
+    settings.setValue(prefix + "/showClosedWon", mShowClosedWon);
+    settings.setValue(prefix + "/showClosedLost", mShowClosedLost);
     settings.setValue(prefix + "/shownPriority", mShownPriority);
 
     // Allow saving searches using this function
@@ -188,7 +202,8 @@ void OpportunityFilterSettings::load(const QSettings &settings, const QString &p
     mModifiedAfter = settings.value(prefix + "/modifiedAfter").toDate();
     QVariant val = settings.value(prefix + "/showOpen");
     mShowOpen = val.isValid() ? val.toBool() : true;
-    mShowClosed = settings.value(prefix + "/showClosed").toBool();
+    mShowClosedWon = settings.value(prefix + "/showClosedWon").toBool();
+    mShowClosedLost = settings.value(prefix + "/showClosedLost").toBool();
     mShownPriority = settings.value(prefix + "/shownPriority").toString();
 
     // Allow loading searches using this function

--- a/client/src/utilities/opportunityfiltersettings.h
+++ b/client/src/utilities/opportunityfiltersettings.h
@@ -55,9 +55,10 @@ public:
     QDate modifiedAfter() const { return mModifiedAfter; }
     void setModifiedBefore(const QDate &modifiedBefore);
     QDate modifiedBefore() const { return mModifiedBefore; }
-    void setShowOpenClosed(bool showOpen, bool showClosed);
+    void setShowOpenClosed(bool showOpen, bool showClosedWon, bool showClosedLost);
     bool showOpen() const { return mShowOpen; }
-    bool showClosed() const { return mShowClosed; }
+    bool showClosedWon() const { return mShowClosedWon; }
+    bool showClosedLost() const { return mShowClosedLost; }
     void setShownPriority(const QString &shownPriority);
     QString shownPriority() const { return mShownPriority; }
     void setSearchName(const QString &searchName);
@@ -85,7 +86,8 @@ private:
     QDate mModifiedBefore, mModifiedAfter;
     MaxNextStepDate mMaxDateIndex = NoDate;
     bool mShowOpen = true;
-    bool mShowClosed = false;
+    bool mShowClosedWon = false;
+    bool mShowClosedLost = false;
     QString mSearchName;
     QString mSearchText;
 };


### PR DESCRIPTION
We have a use-case where we only would like to look at closed lost or
closed won opps. Make it easy to filter by them via the filter widget.

It probably makes less sense for the other less used sales stages. In
theory the right widget would be a drop-down list of check boxes with all
individual sales stages, but that's probably overkill.

![fatcrm-opps-closed-won-lost](https://user-images.githubusercontent.com/30826/81380467-423a3480-910b-11ea-8546-860087fa4c2f.png)