### PR TITLE
Port to QtKeychain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,6 @@ find_package(KF5IconThemes CONFIG REQUIRED)
 find_package(KF5TextWidgets CONFIG REQUIRED)
 find_package(KF5WidgetsAddons CONFIG REQUIRED)
 find_package(KF5WindowSystem CONFIG REQUIRED)
-find_package(KF5Wallet CONFIG REQUIRED)
 find_package(KF5ConfigWidgets CONFIG REQUIRED)
 
 # KDChart is potentially a dependency of KDReports
@@ -95,6 +94,8 @@ set_package_properties(ICU PROPERTIES
   TYPE OPTIONAL
   PURPOSE "Required to localize country names"
 )
+
+find_package(Qt5Keychain REQUIRED)
 
 if(PhoneNumber_FOUND AND ICU_FOUND)
     set(USE_PHONENUMBER 1)

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -19,16 +19,5 @@ endif()
 
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
-if(APPLE OR WIN32)
-  set(_default_kwallet_option 0)
-else()
-  set(_default_kwallet_option 1)
-endif()
-option(USE_KWALLET "Use KWallet for password storage (default 1 on Unix, 0 on Windows/Mac)" ${_default_kwallet_option})
-if(USE_KWALLET)
-  find_package(KF5Wallet ${KF5_VERSION} CONFIG REQUIRED)
-endif()
-configure_file(config-kwallet.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config-kwallet.h)
-
 add_subdirectory(salesforce)
 add_subdirectory(sugarcrm)

--- a/resources/config-kwallet.h.cmake
+++ b/resources/config-kwallet.h.cmake
@@ -1,1 +1,0 @@
-#cmakedefine01 USE_KWALLET

--- a/resources/sugarcrm/CMakeLists.txt
+++ b/resources/sugarcrm/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(akonadi_sugarcrm_resource_private
         KF5::CalendarCore
         KF5::AkonadiContact
         KF5::WindowSystem
+        qt5keychain
     PUBLIC
         KF5::AkonadiAgentBase
         KF5::Contacts
@@ -81,11 +82,7 @@ if(KCALENDARCORE_REQUIRES_KDE4SUPPORT)
     KF5::KDELibs4Support
   )
 endif()
-if(USE_KWALLET)
-  target_link_libraries(akonadi_sugarcrm_resource_private PRIVATE
-    KF5::Wallet
-  )
-endif()
+
 target_link_libraries(akonadi_sugarcrm_resource_private PRIVATE KDReports::kdreports)
 
 target_link_libraries(akonadi_sugarcrm_resource PRIVATE

--- a/resources/sugarcrm/passwordhandler.h
+++ b/resources/sugarcrm/passwordhandler.h
@@ -24,8 +24,6 @@
 #include <QObject>
 #include <QWidget>
 
-#include <config-kwallet.h>
-
 class PasswordHandler : public QObject
 {
     Q_OBJECT
@@ -39,18 +37,12 @@ public:
 Q_SIGNALS:
     void passwordAvailable();
 
-private Q_SLOTS:
-    void onWalletOpened(bool success);
-
 private:
-#if USE_KWALLET
     bool savePassword();
-
-    WId m_winId;
-    bool mWalletOpened;
-#endif
     QString mPassword;
     const QString mResourceId;
+    bool mKeychainOpened = false;
+    bool mDeniedByUser = false;
 };
 
 #endif // PASSWORDHANDLER_H


### PR DESCRIPTION
Currently we optionally use KWallet to store passwords and fall back to
storing it in a settings file.

Instead use QtKeychain to store the password in the platforms respective
native API (which happens to be KWallet on Plasma).

This should improve the cross-platformness of the app and matches the
general direction KDE is taking wrt KWallet.

It also considerably simplifies the implifies the implementation since
we no longer need to handle the optionalness of KWallet